### PR TITLE
Store and format user join date in profile

### DIFF
--- a/memofold/src/components/navbar.jsx
+++ b/memofold/src/components/navbar.jsx
@@ -65,9 +65,19 @@ const Navbar = ({ onDarkModeChange }) => {
 
                 if (response.ok) {
                     const result = await response.json();
-                    const userData = result.user; // Extract user data from the nested structure
+                    const userData = result.user; // extract user object
 
+                    // Update state
                     setCurrentUserProfile(userData);
+
+                    // Save only the needed fields with custom keys
+                    localStorage.setItem("userId", userData._id);
+                    localStorage.setItem("realname", userData.realname);
+                    localStorage.setItem("username", userData.username);
+                    localStorage.setItem("email", userData.email);
+                    localStorage.setItem("createdAt", userData.createdAt);
+                    localStorage.setItem("updatedAt", userData.updatedAt);
+
                     if (userData.profilePic) {
                         setProfilePic(userData.profilePic);
                         localStorage.setItem("profilePic", userData.profilePic);

--- a/memofold/src/components/profile/profile.jsx
+++ b/memofold/src/components/profile/profile.jsx
@@ -143,7 +143,16 @@ const ProfilePage = () => {
     const [isUpdatingPost, setIsUpdatingPost] = useState(false);
     const [isDeletingPost, setIsDeletingPost] = useState(false);
     const [isCreatingPost, setIsCreatingPost] = useState(false);
-    const joinedDate = localStorage.getItem("joinedDateFormatted");
+    const joinedDate = localStorage.getItem("createdAt");
+
+    let formattedDate = "";
+    if (joinedDate) {
+        formattedDate = new Date(joinedDate).toLocaleDateString("en-IN", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+        });
+    }
 
     const startEditPost = (postId) => {
         const postToEdit = posts.find((post) => post._id === postId);
@@ -1709,7 +1718,7 @@ const ProfilePage = () => {
                                     >
                                         <div className="flex items-center">
                                             <FaCalendar className="mr-1" />
-                                            <span>Joined {joinedDate}</span>
+                                            <span>Joined {formattedDate}</span>
                                         </div>
                                     </div>
                                     <div


### PR DESCRIPTION
User join date is now saved as 'createdAt' in localStorage and formatted for display in the profile page. This improves consistency and ensures the date is shown in a readable format.